### PR TITLE
Use a connection string for database

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,11 +52,7 @@ jobs:
       postgres:
         image: postgres:10.8
         env:
-          POSTGRES_USER: ink
-          POSTGRES_INSTANCE: 127.0.0.1
-          POSTGRES_DB: ci_test
-          POSTGRES_PASSWORD: ink
-          POSTGRES_PORT: 5432
+          DATABASE_URL: postgres://ink:ink@127.0.0.1:5432/ci_test
         ports:
         - 5432:5432
     strategy:
@@ -79,11 +75,8 @@ jobs:
       env:
         CI: true
         NODE_ENV: test
-        POSTGRE_DB: ci_test
-        POSTGRE_USER: ink
-        POSTGRE_PASSWORD: ink
-        POSTGRE_INSTANCE: 127.0.0.1
-    
+        DATABASE_URL: postgres://ink:ink@127.0.0.1:5432/ci_test
+
   check-branch:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: 
+on:
   push:
     branches: [dev, main]
   pull_request:
@@ -14,7 +14,7 @@ jobs:
         node-version: [14.x]
     steps:
     - uses: actions/checkout@v3
-      with: 
+      with:
         ssh-key: ${{ secrets.SSH_KEY }}
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
@@ -43,7 +43,7 @@ jobs:
     - name: npm lint
       run: npm run lint
       env:
-        CI: true 
+        CI: true
 
   tests:
     runs-on: ubuntu-latest
@@ -52,7 +52,11 @@ jobs:
       postgres:
         image: postgres:10.8
         env:
-          DATABASE_URL: postgres://ink:ink@127.0.0.1:5432/ci_test
+          POSTGRES_USER: ink
+          POSTGRES_INSTANCE: 127.0.0.1
+          POSTGRES_DB: ci_test
+          POSTGRES_PASSWORD: ink
+          POSTGRES_PORT: 5432
         ports:
         - 5432:5432
     strategy:

--- a/deployments-dev.md
+++ b/deployments-dev.md
@@ -1,3 +1,6 @@
+June 28, 2022
+* add a database connection string
+
 June 7, 2022
 * docker environment
 

--- a/guides/development.md
+++ b/guides/development.md
@@ -63,20 +63,16 @@ commit to convert the code into Standard style.
 The server uses environment variables for configuration. The environment variables can be set in a
 .env file
 
-| Var                | Description                                                                                                                        |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `AUDIENCE`         | the expected audience for [JWT](https://jwt.io) tokens.                                                                            |
-| `DEPLOY_STAGE`     | deployment stage. One of `production`, `staging`, or `development`.                                                                |
-| `DEV_PASSWORD`     | a basic auth password used when in development or staging. Username is `admin`.                                                    |
-| `DOMAIN`           | domain name of the server. If the server is hit with HTTP, redirects to https: plus this domain.                                   |
-| `ISSUER`           | expected issuer for JWT tokens.                                                                                                    |
-| `NODE_ENV`         | environment variable used by [express](https://expressjs.com/). Can be `production` or `development`.                              |
-| `SECRETORKEY`      | expected shared secret for [JWT](https://jwt.io) tokens.                                                                           |
-| `POSTGRE_INSTANCE` | the db server. Set it to 'localhost' for a local dev. If this variable is not set, the models will be stored in a SQLite database. |
-| `POSTGRE_DB`       | the name of the database.                                                                                                          |
-| `POSTGRE_USER`     | the user name to use for the connection                                                                                            |
-| `POSTGRE_PASSWORD` | the password                                                                                                                       |
-| `SQLITE_DB`        | filename of the SQLite database to store data if `POSTGRE_INSTANCE` is not set. Defaults to `./dev.sqlite3`.                       |
+|      Var       |                                              Description                                              |
+| -------------- | ----------------------------------------------------------------------------------------------------- |
+| `AUDIENCE`     | the expected audience for [JWT](https://jwt.io) tokens.                                               |
+| `DEPLOY_STAGE` | deployment stage. One of `production`, `staging`, or `development`.                                   |
+| `DEV_PASSWORD` | a basic auth password used when in development or staging. Username is `admin`.                       |
+| `DOMAIN`       | domain name of the server. If the server is hit with HTTP, redirects to https: plus this domain.      |
+| `ISSUER`       | expected issuer for JWT tokens.                                                                       |
+| `NODE_ENV`     | environment variable used by [express](https://expressjs.com/). Can be `production` or `development`. |
+| `SECRETORKEY`  | expected shared secret for [JWT](https://jwt.io) tokens.                                              |
+| `DATABASE_URL` | e.g `postgres://user:pass@localhost:5432/dbname`                                                      |
 
 ## Versioning
 

--- a/knexfile.js
+++ b/knexfile.js
@@ -4,12 +4,7 @@ require('dotenv').config()
 const path = require('path')
 module.exports = {
   client: 'pg',
-  connection: {
-    host: process.env.POSTGRE_INSTANCE,
-    database: process.env.POSTGRE_DB,
-    user: process.env.POSTGRE_USER,
-    password: process.env.POSTGRE_PASSWORD
-  },
+  connection: process.env.DATABASE_URL,
   pool: {
     min: 2,
     max: 10

--- a/tests/google-integration/index.js
+++ b/tests/google-integration/index.js
@@ -7,7 +7,7 @@ require('dotenv').config()
 const allTests = async () => {
   await app.initialize(true)
   await app.knex.migrate.rollback()
-  if (process.env.POSTGRE_DB === 'ci_test') {
+  if (process.env.DATABASE_URL === 'postgres://ink:ink@127.0.0.1:5432/ci_test') {
     await app.knex.migrate.latest()
   }
 

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -141,7 +141,7 @@ require('dotenv').config()
 const allTests = async () => {
   await app.initialize(true)
   await app.knex.migrate.rollback()
-  if (process.env.POSTGRE_DB === 'ci_test') {
+  if (process.env.DATABASE_URL === 'postgres://ink:ink@127.0.0.1:5432/ci_test') {
     await app.knex.migrate.latest()
   }
 

--- a/tests/models/index.js
+++ b/tests/models/index.js
@@ -30,9 +30,6 @@ require('dotenv').config()
 const allTests = async () => {
   await app.initialize(true)
   await app.knex.migrate.rollback()
-  if (process.env.POSTGRE_DB === 'travis_ci_test') {
-    await app.knex.migrate.latest()
-  }
 
   await sourceTests(app)
   // await attributionTests(app) // skipped for now. need to fix create attribution tests


### PR DESCRIPTION
Using a database cluster on Digital Ocean requires a custom `PORT` and an SSL connection. Rather than adding another configuration for this, a connection string provides more flexibility and reduces database configuration down to one parameter.