### PR TITLE
Configure the DB connection with CA certificate

### DIFF
--- a/deployments-dev.md
+++ b/deployments-dev.md
@@ -1,3 +1,6 @@
+June 29, 2022
+* add database CA certificate configuration
+
 June 28, 2022
 * add a database connection string
 

--- a/knexfile.js
+++ b/knexfile.js
@@ -2,9 +2,21 @@
 require('dotenv').config()
 
 const path = require('path')
+
+const connection = {
+  connectionString: process.env.DATABASE_URL
+}
+
+if (process.env.DATABASE_CA_CERT) {
+  connection.ssl = {
+    rejectUnauthorized: true,
+    ca: process.env.DATABASE_CA_CERT
+  }
+}
+
 module.exports = {
   client: 'pg',
-  connection: process.env.DATABASE_URL,
+  connection: connection,
   pool: {
     min: 2,
     max: 10


### PR DESCRIPTION
Only if the environment variable is configured. This is required for deployment environments such as Digital Ocean.